### PR TITLE
websocket-realtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,21 @@ Need an out‑of‑the‑box dashboard? Check the companion project **[ewelinkap
 * **Getting started / API reference →** see the [Wiki Pages](https://github.com/PJanisio/ewelinkApiPhp/wiki)
 * **Developer notes** (architecture, contribution guide) → [Developers Wiki](https://github.com/PJanisio/ewelinkApiPhp/wiki/Developers)
 
+### Realtime listener
+
+The WebSocket client can now stay connected and stream updates instead of opening a socket for a single request. Once the connection is established, you can subscribe to a device and receive updates through a callback:
+
+```php
+$devices = $httpClient->getDevices();
+$devices->listenForUpdates('Kitchen light', function (array $message) {
+    if (isset($message['params'])) {
+        var_dump($message['params']);
+    }
+}, ['switch', 'online'], 30);
+```
+
+This keeps the socket alive for a short listening window and is suitable for real-time dashboards or event-driven monitoring.
+
 ---
 
 ## ⚙️ Requirements

--- a/src/Devices.php
+++ b/src/Devices.php
@@ -524,6 +524,47 @@ class Devices
     }
 
     /**
+     * Listen for a device's live updates over the same WebSocket connection.
+     *
+     * @param string $identifier The device name or ID.
+     * @param callable $callback Callback receiving each decoded message.
+     * @param array|string $params Query parameters to subscribe for.
+     * @param int $seconds How long to stay attached while listening.
+     * @return array<int, mixed> Messages received while listening.
+     */
+    public function listenForUpdates(string $identifier, callable $callback, $params = ['switch', 'online'], int $seconds = 30): array
+    {
+        $deviceId = $this->getDeviceIdByIdentifier($identifier);
+        if (!$deviceId) {
+            throw new Exception("Device not found.");
+        }
+
+        $device = $this->getDeviceById($deviceId);
+        if (!$device) {
+            $errorCode = 'DEVICE_NOT_FOUND';
+            $errorMsg = Constants::ERROR_CODES[$errorCode] ?? 'Unknown error';
+            throw new Exception($errorMsg);
+        }
+
+        if (!isset($this->wsClient)) {
+            $this->wsClient = $this->initializeWebSocketConnection($identifier);
+        }
+
+        $queryData = $this->wsClient->createQueryData($device, $params);
+        $this->wsClient->send(json_encode($queryData));
+
+        return $this->wsClient->listen($callback, $seconds);
+    }
+
+    /**
+     * Backward-friendly alias for the realtime listener.
+     */
+    public function listenForDeviceUpdates(string $identifier, callable $callback, $params = ['switch', 'online'], int $seconds = 30): array
+    {
+        return $this->listenForUpdates($identifier, $callback, $params, $seconds);
+    }
+
+    /**
      * Set data of a device using WebSocket.
      *
      * @param string $identifier The device name or ID.

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -230,7 +230,7 @@ class Utils
         if ($token->checkAndRefreshToken()) {
             $tokenData = $token->getTokenData();
             echo '<h2>You are authenticated!</h2><p>Token expiry: ' .
-                date('Y-m-d H:i:s', $tokenData['atExpiredTime'] / 1000) . '</p>';
+                date('Y-m-d H:i:s', intdiv((int) $tokenData['atExpiredTime'], 1000)) . '</p>';
             Config::warnIfConfigExposed();
             self::showDebugAndJsonLinks();
 

--- a/src/WebSocketClient.php
+++ b/src/WebSocketClient.php
@@ -246,6 +246,50 @@ class WebSocketClient
     }
 
     /**
+     * Listen for incoming websocket events until the timeout expires.
+     *
+     * @param callable $listener Receives decoded JSON payloads as they arrive.
+     * @param int $seconds How long to keep listening before returning.
+     * @return array<int, mixed> Messages received during the listening window.
+     */
+    public function listen(callable $listener, int $seconds = 30): array
+    {
+        if (!$this->socket) {
+            throw new Exception(Constants::ERROR_CODES['NO_VALID_WS_CONNECTION'] ?? 'Unknown error');
+        }
+
+        $messages = [];
+        $deadline = microtime(true) + max(0, $seconds);
+
+        while (microtime(true) < $deadline) {
+            $this->maybePing();
+            $read = [$this->socket];
+            $write = null;
+            $except = null;
+
+            $available = @stream_select($read, $write, $except, 1, 0);
+            if ($available === false || $available === 0) {
+                continue;
+            }
+
+            $payload = $this->receive();
+            if ($payload === '') {
+                continue;
+            }
+
+            $decoded = json_decode($payload, true);
+            if (json_last_error() !== JSON_ERROR_NONE && $payload !== 'null') {
+                $decoded = $payload;
+            }
+
+            $messages[] = $decoded;
+            $listener($decoded);
+        }
+
+        return $messages;
+    }
+
+    /**
      * Close the WebSocket connection and stop the ping process.
      */
     public function close(): void

--- a/tests/HttpClientGatewayTest.php
+++ b/tests/HttpClientGatewayTest.php
@@ -34,7 +34,6 @@ final class HttpClientGatewayTest extends TestCase
         $ok   = curl_exec($ch);                                   // bool|false
         $code = (int) curl_getinfo($ch, CURLINFO_RESPONSE_CODE);  // 0 if none
         $err  = curl_error($ch);
-        curl_close($ch);
 
         /* ── 1. Could not even open the socket → skip, not fail ───────────── */
         if ($ok === false) {

--- a/tests/WebSocketResolveTest.php
+++ b/tests/WebSocketResolveTest.php
@@ -52,9 +52,11 @@ final class WebSocketResolveTest extends TestCase
         $urlProp = new ReflectionProperty($ws, 'url');
         $hostProp = new ReflectionProperty($ws, 'host');
         $portProp = new ReflectionProperty($ws, 'port');
-        $urlProp->setAccessible(true);
-        $hostProp->setAccessible(true);
-        $portProp->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $urlProp->setAccessible(true);
+            $hostProp->setAccessible(true);
+            $portProp->setAccessible(true);
+        }
 
 
         $expectedHost = gethostbyname($domain); // resolves to IP

--- a/tests/WebSocketResolveTest.php
+++ b/tests/WebSocketResolveTest.php
@@ -6,6 +6,7 @@ namespace pjanisio\ewelinkapiphp\Tests;
 
 use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
+use pjanisio\ewelinkapiphp\Config;
 use pjanisio\ewelinkapiphp\HttpClient;
 use pjanisio\ewelinkapiphp\WebSocketClient;
 
@@ -21,7 +22,6 @@ final class DummyHttpClient extends HttpClient
     public function __construct(array $dispatchReply)
     {
         $this->reply = $dispatchReply;
-        parent::__construct();
     }
 
     /** @inheritDoc */
@@ -38,11 +38,12 @@ final class WebSocketResolveTest extends TestCase
      */
     public function testResolverBuildsWsUrl(string $domain, int $port): void
     {
+        Config::setOverrides(['REGION' => 'eu']);
+
         $dummy = new DummyHttpClient([
             'domain' => $domain,
             'port' => $port,
         ]);
-
 
         $ws = new WebSocketClient($dummy);
 


### PR DESCRIPTION
## Summary

This PR adds a real-time listener mode for the WebSocket client and a device-level helper to keep the socket alive while updates are streamed instead of polling per request.

## Changes

- Added WebSocketClient::listen() to read incoming frames continuously and invoke a callback.
- Added Devices::listenForUpdates() and Devices::listenForDeviceUpdates() helpers for live device event streaming.
- Updated README with a realtime listener example.
- Fixed the WS resolver test setup to ensure configuration overrides are used correctly in tests.

## Related issue

Closes #65
